### PR TITLE
Procfile有りの検証を行うためrevert

### DIFF
--- a/db/migrate/20161226053443_add_size_to_items.rb
+++ b/db/migrate/20161226053443_add_size_to_items.rb
@@ -1,5 +1,0 @@
-class AddSizeToItems < ActiveRecord::Migration
-  def change
-    add_column :items, :size, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161226053443) do
+ActiveRecord::Schema.define(version: 20161222083437) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "items", force: :cascade do |t|
     t.string   "name"
-    t.string   "size"
     t.integer  "price"
     t.text     "description"
     t.datetime "created_at",  null: false


### PR DESCRIPTION
Procfileなしでのadd_size_to_itemsコミットの検証が完了し、
次にProfileありでのadd_size_to_itemsコミットを行うため
add_size_to_itemsコミットを取り消す

This reverts commit 35b0dc8d1c98e7214ed95d551abdce7b64595c21, reversing
changes made to 05761347d5f0831b283e1cb2175ebcd22ec74e98.